### PR TITLE
feat: support international number formats in convertNumberToRoman and bump version to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ import {
 Using jsDelivr CDN (ES5 UMD browser module):
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/cr-numeral@1.2.7/dist/app.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/cr-numeral@2.1.0/dist/app.min.js"></script>
 ```
 
 Using unpkg CDN:
 
 ```html
-<script src="https://unpkg.com/cr-numeral@1.2.7/dist/app.min.js"></script>
+<script src="https://unpkg.com/cr-numeral@2.1.0/dist/app.min.js"></script>
 ```
 
 ## Usage
@@ -111,6 +111,7 @@ console.log(toRoman, toNumber, validateNumeral);
 - Convert a Number to a Roman Numeral `convertNumberToRoman(number)`
 - Convert a Roman Numeral to a Number `convertRomanToNumber("Numeral")`
 - Validate a Roman Numeral input `numeralValidation("Numeral")`
+- Support international numeric inputs when converting numbers (e.g. `2,021`, `20,21` for Indian grouping, and `2.021`)
 
 ### NodeJS
 

--- a/modules/numberToRomanNumeral.ts
+++ b/modules/numberToRomanNumeral.ts
@@ -1,22 +1,61 @@
 import { roman, numbers } from "./algorithm/algorithm";
 
+const parseInternationalNumber = (num: number | boolean | string): number | null => {
+  if (typeof num === "boolean") return null;
+
+  if (typeof num === "number") {
+    return Number.isInteger(num) ? num : null;
+  }
+
+  if (typeof num !== "string") return null;
+
+  const trimmedValue = num.trim();
+  if (!trimmedValue) return null;
+
+  const normalizedValue = trimmedValue.replace(/\s/g, "");
+
+  // 1,234,567 (international) / 12,34,567 (Indian)
+  const commaGroupedPattern = /^(\d{1,3})(,\d{2,3})+$/;
+  const europeanPattern = /^\d{1,3}(\.\d{3})+(,\d+)?$/;
+
+  let digitsOnly = normalizedValue;
+
+  if (commaGroupedPattern.test(normalizedValue)) {
+    digitsOnly = normalizedValue.replace(/,/g, "");
+  } else if (europeanPattern.test(normalizedValue)) {
+    digitsOnly = normalizedValue.replace(/\./g, "").split(",")[0];
+  } else if (/^\d+$/.test(normalizedValue)) {
+    digitsOnly = normalizedValue;
+  } else {
+    return null;
+  }
+
+  if (!/^\d+$/.test(digitsOnly)) return null;
+
+  const parsed = Number(digitsOnly);
+  if (!Number.isSafeInteger(parsed)) return null;
+
+  return parsed;
+};
+
 const convertNumberToRoman = (num: number | boolean | string): string => {
   let romanNumeral = "";
 
-  if (typeof num === "boolean")
-    return "Cannot use Boolean values!!!";
-  if (typeof num !== "number")
-    return "You must provide only valid numbers!!!";
+  if (typeof num === "boolean") return "Cannot use Boolean values!!!";
 
-  if (num > 0) {
-    let remainingNum = num;
+  const parsedNumber = parseInternationalNumber(num);
+  if (parsedNumber === null) return "You must provide only valid numbers!!!";
+
+  if (parsedNumber > 0) {
+    let remainingNum = parsedNumber;
     while (remainingNum !== 0) {
-      const index = numbers.findIndex((num: number) => remainingNum >= num);
+      const index = numbers.findIndex((number: number) => remainingNum >= number);
       romanNumeral += roman[index];
       remainingNum -= numbers[index];
     }
-  } else
+  } else {
     romanNumeral = "Cannot convert Zero or negative numbers!!!";
+  }
 
   return romanNumeral;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cr-numeral",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cr-numeral",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cr-numeral",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "cr-numeral is a lightweight and versatile npm package designed to effortlessly convert numbers to Roman numerals and vice versa. Whether you're building educational tools, historical applications, or need Roman numeral functionality in your project, cr-numeral provides a simple and efficient solution.",
   "main": "dist/app.js",
   "types": "dist/app.d.ts",

--- a/test/romanNumeralConverter.test.ts
+++ b/test/romanNumeralConverter.test.ts
@@ -31,4 +31,24 @@ describe("Roman Numeral Conversion", () => {
     const resultType: string = typeof romanNumeral;
     expect(resultType).toBe("string");
   });
+
+  it("should support comma separated international format", () => {
+    const romanNumeral: string = convertNumberToRoman("2,021");
+    expect(romanNumeral).toBe("MMXXI");
+  });
+
+  it("should support Indian numbering format", () => {
+    const romanNumeral: string = convertNumberToRoman("20,21");
+    expect(romanNumeral).toBe("MMXXI");
+  });
+
+  it("should support European thousands separators", () => {
+    const romanNumeral: string = convertNumberToRoman("2.021");
+    expect(romanNumeral).toBe("MMXXI");
+  });
+
+  it("should reject malformed formatted strings", () => {
+    const romanNumeral: string = convertNumberToRoman("20,2A1");
+    expect(romanNumeral).toBe("You must provide only valid numbers!!!");
+  });
 });


### PR DESCRIPTION
### Motivation
- Add support for common international numeric formats so `convertNumberToRoman` accepts formatted numeric strings (e.g. `2,021`, Indian-style `20,21`, and European `2.021`) before converting to Roman numerals. 
- Update packaging/version so the change can be released to npm as `2.1.0`.
- No additional skills from `AGENTS.md` were required for this change.

### Description
- Introduced `parseInternationalNumber` in `modules/numberToRomanNumeral.ts` to normalize and parse plain integers and grouped formats (comma-grouped, Indian grouping, and European dot grouping) into a safe integer. 
- Updated `convertNumberToRoman` to call `parseInternationalNumber` and to preserve existing boolean and invalid-input messages. 
- Added tests in `test/romanNumeralConverter.test.ts` that cover international comma grouping, Indian-format grouping, European thousands separators, and malformed formatted strings. 
- Bumped `version` to `2.1.0` in `package.json` and `package-lock.json`, and updated CDN version examples and the features list in `README.md`.

### Testing
- Ran unit tests with `npm test -- --watchAll=false`, and all test suites passed (`2` suites, `29` tests passed). 
- Built the package with `npm run build` (`tsc`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf13a01df08329845dc0c7ffc148e2)